### PR TITLE
feat: add ControlStayOnExit config option to park drone after FPV disconnect

### DIFF
--- a/nzkfc_drone/client/drone_control.lua
+++ b/nzkfc_drone/client/drone_control.lua
@@ -197,6 +197,11 @@ end
 function DroneControl.Stop(droneEntity)
     if not controlling then return end
     controlling = false
+    if Config.ControlStayOnExit then
+        -- Park the drone at its current position instead of resuming follow behaviour.
+        -- DroneMain.SetStay exposes the droneStaying/stayPos upvalues in main.lua.
+        DroneMain.SetStay(true, GetEntityCoords(droneEntity))
+    end
     --SetEntityVisible(PlayerPedId(), true, false) --Disabled
     lib.notify({ type = 'success', title = 'Drone', description = 'Disconnected from drone.' })
 end

--- a/nzkfc_drone/client/main.lua
+++ b/nzkfc_drone/client/main.lua
@@ -8,6 +8,12 @@ function DroneMain.ToggleLight()
     local state = droneLight and 'on' or 'off'
     lib.notify({ type = 'inform', title = 'Drone', description = ('Spotlight %s.'):format(state) })
 end
+-- Allow drone_control.lua to park the drone in place after FPV disconnect.
+-- Called by DroneControl.Stop when Config.ControlStayOnExit is true.
+function DroneMain.SetStay(state, pos)
+    droneStaying = state
+    stayPos      = pos
+end
 local droneSerial   = nil
 local droneHealth   = Config.DroneMaxHealth
 local droneItemSlot = nil

--- a/nzkfc_drone/shared/config.lua
+++ b/nzkfc_drone/shared/config.lua
@@ -43,6 +43,7 @@ Config.ControlAscendSpeed      = 0.1   -- Ascend/descend speed
 Config.ControlYawSensitivity   = 10.0  -- Mouse horizontal turn speed (lower = slower)
 Config.ControlPitchSensitivity = 8.0  -- Mouse vertical look speed (lower = slower)
 Config.ControlCamOffsetZ       = -0.16  -- Camera height on drone (~3 inches below centre)
+Config.ControlStayOnExit       = false  -- true = drone stays parked at its position when the player exits FPV control; false = drone resumes following the player (default)
 
 -- Drone Damage & Health
 Config.DamageEnabled        = true


### PR DESCRIPTION
## Summary

Adds a `Config.ControlStayOnExit` option so that when a player disconnects from FPV/control mode the drone stays parked at the location it was exited at, rather than resuming its default follow behaviour.

## Changes

**`nzkfc_drone/shared/config.lua`**
- New option added under the **Drone Control (FPV mode)** section:
  ```lua
  Config.ControlStayOnExit = false  -- true = drone stays parked at its position when the player exits FPV control; false = drone resumes following the player (default)
  ```

**`nzkfc_drone/client/main.lua`**
- Exposes a new public helper `DroneMain.SetStay(state, pos)` alongside the existing `DroneMain.ToggleLight()`, allowing `drone_control.lua` to set the `droneStaying`/`stayPos` upvalues without direct coupling.

**`nzkfc_drone/client/drone_control.lua`**
- `DroneControl.Stop()` now checks `Config.ControlStayOnExit`; when `true` it calls `DroneMain.SetStay(true, GetEntityCoords(droneEntity))` to park the drone in place before returning control to the player.

## Behaviour

| Config value | On FPV disconnect |
|---|---|
| `false` (default) | Drone resumes following the player — no behaviour change |
| `true` | Drone hovers parked at its exit position; player can recall it with `/calldrone` or the **Stay** toggle |